### PR TITLE
BREAKING CHANGE: move to GitHub based preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Enable Renovate in your repo and just `extends` in `renovate.json`.
 
 ```json5
 {
-  "extends": ["@azu"]
+  "extends": [
+    "github>azu/renovate-config"
+  ]
 }
 ```
 
@@ -19,16 +21,16 @@ Note: Don't necessary to do `npm i -D @azu/renovate-config`
 #### Features
 
 - Auto merge patch and minor version
-- Support Node.js
-- It defined packages that require manually updates like TypeScript, Prettier, Linters
-- Prevent supply-chain attack by `"stabilityDays": 7`
+- Support npm/Node.js ecosystem
+- Defined package groups like TypeScript, Prettier, Linters
+- Prevent supply-chain attack by `"minimumReleaseAge": 7 days`
 
 ### Maintenance preset
 
 ```json5
 {
   "extends": [
-    "@azu:maintenance"
+    "github>azu/renovate-config:non-major"
   ]
 }
 ```
@@ -36,11 +38,11 @@ Note: Don't necessary to do `npm i -D @azu/renovate-config`
 #### Features
 
 Same features with Default preset.
-The only difference from default preset, It does not update major updates.
+The only difference from default preset, It disables major updates.
 
 - Add `{ major: { enabled: false }}`
 
-It aim to less create Pull Request by renovatebot.
+It aims to less create Pull Request by renovate-bot.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you used maintenance preset, you can migrate to GitHub based preset by follow
 ```diff
 {
     "extends": [
--        "@azu/maintenance"
+-        "@azu:maintenance"
 +        "github>azu/renovate-config:non-major"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ The only difference from default preset, It disables major updates.
 
 It aims to less create Pull Request by renovate-bot.
 
+## Migration from npm based preset to GitHub based preset
+
+If you used default preset, you can migrate to GitHub based preset by following steps.
+
+```diff
+{
+  "extends": [
+-    "@azu"
++    "github>azu/renovate-config"
+  ]
+}
+```
+
+If you used maintenance preset, you can migrate to GitHub based preset by following steps.
+
+```diff
+{
+    "extends": [
+-        "@azu/maintenance"
++        "github>azu/renovate-config:non-major"
+    ]
+}
+```
+
 ## References
 
 - [Renovate Docs](https://renovatebot.com/docs/)

--- a/default.json
+++ b/default.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":timezone(Asia/Tokyo)"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "action"
+      ],
+      "pinDigests": false
+    }
+  ],
+  "npm": {
+    "labels": [
+      "dependencies"
+    ],
+    "extends": [
+      ":noUnscheduledUpdates",
+      ":separatePatchReleases",
+      "npm:unpublishSafe",
+      ":prNotPending",
+      "helpers:disableTypesNodeMajor"
+    ],
+    "rangeStrategy": "bump",
+    "automergeType": "branch",
+    "major": {
+      "automerge": false
+    },
+    "minor": {
+      "automerge": true,
+      "groupName": "Minor updates",
+      "minimumReleaseAge": "7 days",
+      "prCreation": "status-success"
+    },
+    "patch": {
+      "automerge": true,
+      "groupName": "Patch updates",
+      "minimumReleaseAge": "7 days",
+      "prCreation": "status-success"
+    },
+    "packageRules": [
+      {
+        "groupName": "Manuall updates",
+        "matchPackageNames": [
+          "eslint",
+          "prettier",
+          "typescript"
+        ],
+        "enabled": false
+      },
+      {
+        "description": "disable package.json > engines update",
+        "matchDepTypes": [
+          "engines"
+        ],
+        "enabled": false
+      },
+      {
+        "groupName": "ts-node",
+        "matchPackageNames": [
+          "ts-node",
+          "ts-node-test-register"
+        ]
+      },
+      {
+        "groupName": "textlint",
+        "matchPackageNames": [
+          "^textlint$",
+          "^textlint-scripts",
+          "^textlint-tester",
+          "^@textlint/"
+        ]
+      },
+      {
+        "groupName": "secretlint",
+        "matchPackageNames": [
+          "^secretlint",
+          "^@secretlint/"
+        ]
+      },
+      {
+        "groupName": "ESLint",
+        "matchPackagePatterns": [
+          "^eslint",
+          "^@typescript-eslint/"
+        ]
+      },
+      {
+        "groupName": "renovate",
+        "automerge": true,
+        "matchPackageNames": [
+          "renovate"
+        ]
+      }
+    ]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-console.log("@azu/renovate-config");

--- a/non-major.json
+++ b/non-major.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>azu/renovate-config"
+  ],
+  "npm": {
+    "major": {
+      "enabled": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
+  "private": true,
   "name": "@azu/renovate-config",
   "description": "Shareable config for Renovate (renovatebot.com)",
   "version": "3.0.2",
   "author": "azu <azuciao@gmail.com>",
-  "main": "index.js",
-  "files": [
-    "index.js"
-  ],
   "scripts": {
-    "test": "renovate-config-validator"
+    "test": "renovate-config-validator default.json && renovate-config-validator non-major.json"
   },
   "devDependencies": {
     "renovate": "^36.94.1"
@@ -25,118 +22,5 @@
     "npm",
     "renovate"
   ],
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
-  "renovate-config": {
-    "default": {
-      "extends": [
-        "config:recommended",
-        ":timezone(Asia/Tokyo)"
-      ],
-      "packageRules": [
-        {
-          "matchDepTypes": [
-            "action"
-          ],
-          "pinDigests": false
-        }
-      ],
-      "npm": {
-        "labels": [
-          "dependencies"
-        ],
-        "extends": [
-          ":noUnscheduledUpdates",
-          ":separatePatchReleases",
-          "npm:unpublishSafe",
-          ":prNotPending",
-          "helpers:disableTypesNodeMajor"
-        ],
-        "rangeStrategy": "bump",
-        "automergeType": "branch",
-        "major": {
-          "automerge": false
-        },
-        "minor": {
-          "automerge": true,
-          "groupName": "Minor updates",
-          "minimumReleaseAge": "7 days",
-          "prCreation": "status-success"
-        },
-        "patch": {
-          "automerge": true,
-          "groupName": "Patch updates",
-          "minimumReleaseAge": "7 days",
-          "prCreation": "status-success"
-        },
-        "packageRules": [
-          {
-            "groupName": "Manuall updates",
-            "matchPackageNames": [
-              "eslint",
-              "prettier",
-              "typescript"
-            ],
-            "enabled": false
-          },
-          {
-            "description": "disable package.json > engines update",
-            "matchDepTypes": [
-              "engines"
-            ],
-            "enabled": false
-          },
-          {
-            "groupName": "ts-node",
-            "matchPackageNames": [
-              "ts-node",
-              "ts-node-test-register"
-            ]
-          },
-          {
-            "groupName": "textlint",
-            "matchPackageNames": [
-              "^textlint$",
-              "^textlint-scripts",
-              "^textlint-tester",
-              "^@textlint/"
-            ]
-          },
-          {
-            "groupName": "secretlint",
-            "matchPackageNames": [
-              "^secretlint",
-              "^@secretlint/"
-            ]
-          },
-          {
-            "groupName": "ESLint",
-            "matchPackagePatterns": [
-              "^eslint",
-              "^@typescript-eslint/"
-            ]
-          },
-          {
-            "groupName": "renovate",
-            "automerge": true,
-            "matchPackageNames": [
-              "renovate"
-            ]
-          }
-        ]
-      }
-    },
-    "maintenance": {
-      "extends": [
-        "@azu"
-      ],
-      "npm": {
-        "major": {
-          "enabled": false
-        }
-      }
-    }
-  }
+  "license": "MIT"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@azu"
+    "github>azu/renovate-config"
   ]
 }


### PR DESCRIPTION
> 
    WARN: Using npm packages for Renovate presets is now deprecated. Please migrate to repository-based presets instead.


npm based preset will be removed.

We need to migrate to GitHub based preset

- [Shareable Config Presets - Renovate Docs | Renovate Docs](https://docs.renovatebot.com/config-presets/#example-configs)